### PR TITLE
Fix linter errors caused by tags

### DIFF
--- a/cmd/felix/main.go
+++ b/cmd/felix/main.go
@@ -31,17 +31,17 @@ type VersionCmd struct{}
 type InitCmd struct{}
 
 type NewCmd struct {
-	Name string `arg required help:"the name of the new service and directory you want to create"`
+	Name string `arg:"" required:"" help:"the name of the new service and directory you want to create"`
 }
 
 var cli struct {
 	Template string `short:"t" help:"github url for the template"`
 
-	Version VersionCmd `cmd help:"list the latest version"`
+	Version VersionCmd `cmd:"" help:"list the latest version"`
 
-	Init InitCmd `cmd help:"creates new service in current directory"`
+	Init InitCmd `cmd:"" help:"creates new service in current directory"`
 
-	New NewCmd `cmd help:"creates new service in new directory"`
+	New NewCmd `cmd:"" help:"creates new service in new directory"`
 }
 
 var (


### PR DESCRIPTION
(From https://github.com/alecthomas/kong#supported-tags)
Tags can be in two forms:

1. Standard Go syntax, eg. kong:"required,name='foo'".
2. Bare tags, eg. required:"" name:"foo"

Both can coexist with standard Tag parsing.